### PR TITLE
Fix for Issue #5 in original repo - Replace stop() with exit() at che…

### DIFF
--- a/webhook_listener/__init__.py
+++ b/webhook_listener/__init__.py
@@ -31,7 +31,7 @@ class Listener(object):
         self.WEBTHREAD.start()
 
     def stop(self):
-        cherrypy.engine.stop()
+        cherrypy.engine.exit()
         self.WEBTHREAD = None
 
     def _startServer(self):


### PR DESCRIPTION
Fix for Issue #5 in original repo - Replace stop() with exit() at cherrypy.engine in Listener.stop()
Fixes: https://github.com/toddrob99/Webhooks/issues/5