### PR TITLE
Add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Install from PyPI using pip
     * threadPool = Number of worker threads for the web server (default: 10)
     * logScreen = Setting for cherrypy to log to screen (default: False)
     * autoReload = Setting for cherrypy to auto reload when python files are changed (default: False)
+    * sslModule = Select which SSL library to use (default: 'builtin')
+    * sslCert = Path to the certificate (SSL is disabled when empty)
+    * sslPrivKey = Path to the certificate's private key (SSL is disabled when empty)
+      see https://cherrypydocrework.readthedocs.io/deploy.html#ssl-support for more information on SSL support
 * Start the Listener
 * Keep your application running so the Listener can run in a separate thread
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Install from PyPI using pip
     * sslModule = Select which SSL library to use (default: 'builtin')
     * sslCert = Path to the certificate (SSL is disabled when empty)
     * sslPrivKey = Path to the certificate's private key (SSL is disabled when empty)
+    * sslCertChain = Path to the full certificate chain
       see https://cherrypydocrework.readthedocs.io/deploy.html#ssl-support for more information on SSL support
 * Start the Listener
 * Keep your application running so the Listener can run in a separate thread

--- a/webhook_listener/__init__.py
+++ b/webhook_listener/__init__.py
@@ -22,6 +22,9 @@ class Listener(object):
         self.logScreen = kwargs.get("logScreen", False)
         self.autoReload = kwargs.get("autoReload", False)
         self.handlers = kwargs.get("handlers", {})
+        self.sslModule = kwargs.get("sslModule", "builtin")
+        self.sslCert = kwargs.get("sslCert", "")
+        self.sslPrivKey = kwargs.get("sslPrivKey", "")
 
     def start(self):
         self.WEBTHREAD = threading.Thread(
@@ -42,6 +45,9 @@ class Listener(object):
                 "server.thread_pool": self.threadPool,
                 "engine.autoreload.on": self.autoReload,
                 "log.screen": self.logScreen,
+                "server.ssl_module": self.sslModule,
+                "server.ssl_certificate": self.sslCert,
+                "server.ssl_private_key": self.sslPrivKey,
             }
         }
         apiConf = {

--- a/webhook_listener/__init__.py
+++ b/webhook_listener/__init__.py
@@ -25,6 +25,7 @@ class Listener(object):
         self.sslModule = kwargs.get("sslModule", "builtin")
         self.sslCert = kwargs.get("sslCert", "")
         self.sslPrivKey = kwargs.get("sslPrivKey", "")
+        self.sslCertChain = kwargs.get("sslCertChain", "")
 
     def start(self):
         self.WEBTHREAD = threading.Thread(
@@ -48,6 +49,7 @@ class Listener(object):
                 "server.ssl_module": self.sslModule,
                 "server.ssl_certificate": self.sslCert,
                 "server.ssl_private_key": self.sslPrivKey,
+                "server.ssl_certificate_chain": self.sslCertChain,
             }
         }
         apiConf = {


### PR DESCRIPTION
Added three new parameters to the webhooks listener class to support SSL encryption.

Used the cherrypy documentation (https://cherrypydocrework.readthedocs.io/deploy.html#ssl-support) to create these and tested it with a self signed certificate.

Also added the parameters to the README.md file.